### PR TITLE
Fix additional_attrs to add attributes via driver, not RM.

### DIFF
--- a/src/clustoec2/drivers/devices/servers/ec2server.py
+++ b/src/clustoec2/drivers/devices/servers/ec2server.py
@@ -354,7 +354,7 @@ class EC2VirtualServer(BasicVirtualServer, EC2Mixin):
 
         self._i = reservation.instances[0]
         self._i.add_tag('Name', self.name)
-        result = mgr.additional_attrs(self, resource={'instance': self._i})
+        result = mgr.additional_attrs(self, resource={'instance': self._i}, number=res.number)
         if wait:
             self.poll_until('running')
 

--- a/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
+++ b/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
@@ -5,6 +5,7 @@
 #
 
 from boto import ec2
+from clusto import get_entities
 from clusto.drivers.base import ResourceManager
 from clusto.exceptions import ResourceException
 
@@ -140,13 +141,20 @@ class EC2ConnectionManager(ResourceManager):
         additional attributes that share the resourcemanager's attr_key.
         """
         for ref in self.references():
-            thing = clusto.get_entities([ref.entity.name])[0]
+            thing = get_entities([ref.entity.name])[0]
             for attr in thing.attrs(self._attr_name):
                 if not attr.number == ref.number:
+                    print 'Changing {0}\'s incorrect attribute...'.format(thing.name)
                     thing.set_attr(
                         key=attr.key,
                         subkey=attr.subkey,
                         # Replicate all values except the number.
                         number=ref.number,
+                        value=attr.value
+                    )
+                    thing.del_attrs(
+                        key=attr.key,
+                        subkey=attr.subkey,
+                        number=attr.number,
                         value=attr.value
                     )

--- a/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
+++ b/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
@@ -100,19 +100,19 @@ class EC2ConnectionManager(ResourceManager):
         """
 
         for name, val in resource.items():
-            data = None
             if isinstance(val, ec2.instance.Instance):
                 data = self._instance_to_dict(val)
             elif isinstance(val, ec2.securitygroup.SecurityGroup):
                 data = self._security_group_to_dict(val)
             else:
-                pass
+                data = None
+
+            logging.debug(data)
             if data:
-                self.set_resource_attr(
-                    thing,
-                    resource,
+                thing.add_attr(
+                    key=self._attr_name,
+                    subkey=name,
                     number=number,
-                    key=name,
                     value=data
                 )
                 return data

--- a/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
+++ b/src/clustoec2/drivers/resourcemanagers/ec2connmanager.py
@@ -133,3 +133,20 @@ class EC2ConnectionManager(ResourceManager):
         ) or 'us-east-1'
 
         return (self._connection_to_dict(self._connection(region)), True)
+
+    def reconcile_additional_attrs(self):
+        """
+        Will correct the number of any incorrectly set attributes from
+        additional attributes that share the resourcemanager's attr_key.
+        """
+        for ref in self.references():
+            thing = clusto.get_entities([ref.entity.name])[0]
+            for attr in thing.attrs(self._attr_name):
+                if not attr.number == ref.number:
+                    thing.set_attr(
+                        key=attr.key,
+                        subkey=attr.subkey,
+                        # Replicate all values except the number.
+                        number=ref.number,
+                        value=attr.value
+                    )

--- a/src/clustoec2/drivers/resourcemanagers/vpcconnmanager.py
+++ b/src/clustoec2/drivers/resourcemanagers/vpcconnmanager.py
@@ -85,11 +85,10 @@ class VPCConnectionManager(ec2connmanager.EC2ConnectionManager):
 
             logging.debug(data)
             if data:
-                self.set_resource_attr(
-                    thing,
-                    resource,
+                thing.add_attr(
+                    key=self._attr_name,
+                    subkey=name,
                     number=number,
-                    key=name,
                     value=data
                 )
                 return data


### PR DESCRIPTION
This will fix `create()` throwing an exception about the instance not being assigned to the driver we're trying to assign it to.
